### PR TITLE
allowing api connection again

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -18,7 +18,7 @@ http {
             proxy_pass https://api.musicinfo.pro/;
             proxy_set_header Host api.musicinfo.pro;
             proxy_ssl_server_name on;
-            proxy_ssl_verify on;
+            proxy_ssl_verify off;
             proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
         }
     }


### PR DESCRIPTION
setting verify ssl to off in nginx.conf since the api was using a self signed cetificate and nginx refused connection